### PR TITLE
Show day two agenda on launch during conference day two

### DIFF
--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaFragment.java
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaFragment.java
@@ -77,7 +77,7 @@ public class AgendaFragment extends BaseFragment implements AgendaContract.View 
             // set current day to second if today matches
             Calendar today = Calendar.getInstance();
             Calendar dayTwo = Calendar.getInstance();
-            dayTwo.set(2017, 4, 10);
+            dayTwo.set(2017, Calendar.APRIL, 11);
             if (today.equals(dayTwo)) {
                 viewPager.setCurrentItem(1);
             }


### PR DESCRIPTION
Regarding issue #34, the code to launch the app to the second day during the second day of the conference was in place, but written incorrectly. The `Calendar.set()` method takes the month as a constant `int` that **doesn't** match the actual month number of the year. (I think `4` points to [May](https://developer.android.com/reference/java/util/Calendar.html#MAY) for some reason…) The day of the month (third argument) is also not zero-based, but one-based, so the 11th should be input as `11`.