### PR TITLE
Enabled automated build, and enforce ktLint, detekt, and lint checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
         command: cd Droidcon-Boston && ./gradlew lint test
 
     - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-        path: app/build/reports
+        path: Droidcon-Boston/app/build/reports
         destination: reports
 
     - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
-        path: app/build/test-results
+        path: Droidcon-Boston/app/build/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2
+jobs:
+  build:
+    docker:
+    - image: circleci/android:api-28-alpha
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+
+    steps:
+    - checkout:
+
+    - restore_cache:
+        key: jars-{{ checksum "Droidcon-Boston/build.gradle" }}-{{ checksum  "Droidcon-Boston/app/build.gradle" }}
+
+    - run:
+       name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+       command: cd Droidcon-Boston && pwd && ls && sudo chmod +x ./gradlew
+
+    - run:
+        name: Download Dependencies
+        command: cd Droidcon-Boston && ./gradlew androidDependencies
+
+    - save_cache:
+        paths:
+        - .gradle
+        key: jars-{{ checksum "Droidcon-Boston/build.gradle" }}-{{ checksum  "Droidcon-Boston/app/build.gradle" }}
+
+    - run:
+        name: Run Tests
+        command: cd Droidcon-Boston && ./gradlew lint test
+
+    - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+        path: app/build/reports
+        destination: reports
+
+    - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+        path: app/build/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
     - run:
         name: Static Analysis Checks
-        command: cd Droidcon-Boston && ./gradlew detekt ktlintCheck lint
+        command: cd Droidcon-Boston && ./gradlew detekt ktlintCheck lint evaluateViolations
         
     - run:
         name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,12 @@ jobs:
         key: jars-{{ checksum "Droidcon-Boston/build.gradle" }}-{{ checksum  "Droidcon-Boston/app/build.gradle" }}
 
     - run:
+        name: Static Analysis Checks
+        command: cd Droidcon-Boston && ./gradlew detekt ktlintCheck lint
+        
+    - run:
         name: Run Tests
-        command: cd Droidcon-Boston && ./gradlew lint test
+        command: cd Droidcon-Boston && ./gradlew test
 
     - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
         path: Droidcon-Boston/app/build/reports

--- a/Droidcon-Boston/app/build.gradle
+++ b/Droidcon-Boston/app/build.gradle
@@ -59,8 +59,8 @@ android {
 
 staticAnalysis {
     penalty {
-        maxErrors = 0
-        maxWarnings = 0
+        maxErrors = 150 // current threshold value
+        maxWarnings = 70 // current threshold value
     }
 
     lintOptions {

--- a/Droidcon-Boston/app/build.gradle
+++ b/Droidcon-Boston/app/build.gradle
@@ -1,7 +1,12 @@
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'io.fabric'
+apply plugin: 'com.novoda.static-analysis'
+apply plugin: "io.gitlab.arturbosch.detekt"
+apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
     compileSdkVersion 28
@@ -49,6 +54,31 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+staticAnalysis {
+    penalty {
+        maxErrors = 0
+        maxWarnings = 0
+    }
+
+    lintOptions {
+        lintConfig rootProject.file('team-props/lint-config.xml')
+        checkReleaseBuilds false
+        warningsAsErrors true
+    }
+
+    detekt {
+        config = rootProject.files('team-props/detekt-config.yml')
+        filters = '.*test.*,.*/resources/.*,.*/tmp/.*'
+    }
+
+    ktlint {
+        android true
+        reporters = [ReporterType.CHECKSTYLE]
+
+        includeVariants { variant -> variant.name.contains('debug') }
     }
 }
 

--- a/Droidcon-Boston/build.gradle
+++ b/Droidcon-Boston/build.gradle
@@ -8,6 +8,10 @@ buildscript {
     maven {
       url 'https://maven.fabric.io/public'
     }
+
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.0'
@@ -17,7 +21,12 @@ buildscript {
 
     classpath 'com.google.gms:google-services:4.0.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath 'io.fabric.tools:gradle:1.25.4'
+    classpath 'io.fabric.tools:gradle:1.25.4'\
+
+    // static analysis plugins
+    classpath 'com.novoda:gradle-static-analysis-plugin:0.8'
+    classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC12'
+    classpath 'gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:5.1.0'
   }
 }
 

--- a/Droidcon-Boston/team-props/detekt-config.yml
+++ b/Droidcon-Boston/team-props/detekt-config.yml
@@ -1,0 +1,345 @@
+autoCorrect: true
+
+test-pattern:
+  active: true
+  patterns:
+  - '.*/test/.*'
+  - '.*Test.kt'
+  - '.*Spec.kt'
+  exclude-rule-sets:
+  - 'comments'
+  exclude-rules:
+  - 'NamingRules'
+  - 'WildcardImport'
+  - 'MagicNumber'
+  - 'MaxLineLength'
+  - 'LateinitUsage'
+  - 'StringLiteralDuplication'
+  - 'SpreadOperator'
+  - 'TooManyFunctions'
+
+processors:
+  active: true
+
+console-reports:
+  active: true
+
+output-reports:
+  active: true
+
+comments:
+  active: true
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  EndOfSentenceFormat:
+    active: false
+    endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!]$)
+  UndocumentedPublicClass:
+    active: false
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+  UndocumentedPublicFunction:
+    active: false
+
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+  ComplexInterface:
+    active: false
+    includeStaticDeclarations: false
+  ComplexMethod:
+    active: true
+    ignoreSingleWhenExpression: false
+  LabeledExpression:
+    active: false
+  LargeClass:
+    active: true
+  LongMethod:
+    active: true
+  LongParameterList:
+    active: true
+    ignoreDefaultParameters: false
+  MethodOverloading:
+    active: false
+  NestedBlockDepth:
+    active: true
+  StringLiteralDuplication:
+    active: false
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 11
+    thresholdInClasses: 11
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: "^(ignore|expected).*"
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: false
+    methodNames: 'toString,hashCode,equals,finalize'
+  InstanceOfCheckForException:
+    active: false
+  NotImplementedDeclaration:
+    active: false
+  PrintStackTrace:
+    active: false
+  RethrowCaughtException:
+    active: false
+  ReturnFromFinally:
+    active: false
+  SwallowedException:
+    active: false
+  ThrowingExceptionFromFinally:
+    active: false
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: false
+    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+  ThrowingNewInstanceOfSameException:
+    active: false
+  TooGenericExceptionCaught:
+    active: true
+    exceptionNames:
+    - ArrayIndexOutOfBoundsException
+    - Error
+    - Exception
+    - IllegalMonitorStateException
+    - NullPointerException
+    - IndexOutOfBoundsException
+    - RuntimeException
+    - Throwable
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+    - Error
+    - Exception
+    - Throwable
+    - RuntimeException
+
+naming:
+  active: true
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  FunctionNaming:
+    active: true
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    excludeClassPattern: '$^'
+  MatchingDeclarationName:
+    active: true
+  MemberNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
+  ObjectPropertyNaming:
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+
+performance:
+  active: true
+  ForEachOnRange:
+    active: true
+  SpreadOperator:
+    active: true
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  DuplicateCaseInWhenExpression:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: false
+  EqualsWithHashCodeExist:
+    active: true
+  ExplicitGarbageCollectionCall:
+    active: true
+  InvalidRange:
+    active: false
+  IteratorHasNextCallsNextMethod:
+    active: false
+  IteratorNotThrowingNoSuchElementException:
+    active: false
+  LateinitUsage:
+    active: false
+    excludeAnnotatedProperties: ""
+    ignoreOnClassesPattern: ""
+  UnconditionalJumpStatementInLoop:
+    active: false
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: false
+  UnsafeCast:
+    active: false
+  UselessPostfixExpression:
+    active: false
+  WrongEqualsTypeParameter:
+    active: false
+
+style:
+  active: true
+  CollapsibleIfStatements:
+    active: false
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix: 'to'
+  EqualsNullCall:
+    active: false
+  ExpressionBodySyntax:
+    active: false
+  ForbiddenComment:
+    active: true
+    values: 'TODO:,FIXME:,STOPSHIP:'
+  ForbiddenImport:
+    active: false
+    imports: ''
+  FunctionOnlyReturningConstant:
+    active: false
+    ignoreOverridableFunction: true
+    excludedFunctions: 'describeContents'
+  LoopWithTooManyJumpStatements:
+    active: false
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    ignoreNumbers: '-1,0,1,2'
+    ignoreHashCodeFunction: false
+    ignorePropertyDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: false
+    excludeImportStatements: false
+  MayBeConst:
+    active: false
+  ModifierOrder:
+    active: true
+  NestedClassesVisibility:
+    active: false
+  NewLineAtEndOfFile:
+    active: true
+  NoTabs:
+    active: false
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  OptionalWhenBraces:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: false
+  RedundantVisibilityModifierRule:
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions: "equals"
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: false
+  SpacingBetweenPackageAndImports:
+    active: false
+  ThrowsCount:
+    active: true
+    max: 2
+  TrailingWhitespace:
+    active: false
+  UnnecessaryAbstractClass:
+    active: false
+  UnnecessaryInheritance:
+    active: false
+  UnnecessaryParentheses:
+    active: false
+  UntilInsteadOfRangeTo:
+    active: false
+  UnusedImports:
+    active: false
+  UnusedPrivateMember:
+    active: false
+  UseDataClass:
+    active: false
+    excludeAnnotatedClasses: ""
+  UtilityClassWithPublicConstructor:
+    active: false
+  WildcardImport:
+    active: true
+    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'

--- a/Droidcon-Boston/team-props/lint-config.xml
+++ b/Droidcon-Boston/team-props/lint-config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+
+</lint>


### PR DESCRIPTION
- configures the project to be built by CircleCi
- adds static analysis plugins to run ktlint and detekt
- runs ktlintCheck, detekt, and lint checks on each commit
- sets an initial acceptable threshold of 150 errors and 70 warnings since that is what is currently reported
- a large portion of these errors/warnings are fairly simple updates, and could easily be addressed in a separate PR after which we could then lower the error/warning thresholds

Added a wiki page to document the build process: https://github.com/Droidcon-Boston/conference-app-android/wiki/Automated-Build-Process