### PR TITLE
Consolidated hardcoded event dates to build config fields

### DIFF
--- a/Droidcon-Boston/app/build.gradle
+++ b/Droidcon-Boston/app/build.gradle
@@ -23,6 +23,13 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        buildConfigField "int", "EVENT_YEAR", "2018"
+        buildConfigField "int", "EVENT_MONTH", "03"
+        buildConfigField "int", "EVENT_DAY_ONE", "26"
+        buildConfigField "int", "EVENT_DAY_TWO", "27"
+        buildConfigField "String", "EVENT_DAY_ONE_STRING", "\"03/26/2018\""
+        buildConfigField "String", "EVENT_DAY_TWO_STRING", "\"03/27/2018\""
     }
 
     signingConfigs {

--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/data/Schedule.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/data/Schedule.kt
@@ -55,7 +55,5 @@ class Schedule {
 
     companion object {
         var SCHEDULE_ITEM_ROW = "schedule_item_row"
-        var MONDAY = "03/26/2018"
-        var TUESDAY = "03/27/2018"
     }
 }

--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaDayPagerAdapter.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaDayPagerAdapter.kt
@@ -2,6 +2,7 @@ package com.mentalmachines.droidcon_boston.views.agenda
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import com.mentalmachines.droidcon_boston.BuildConfig
 import com.mentalmachines.droidcon_boston.data.Schedule
 
 class AgendaDayPagerAdapter internal constructor(
@@ -18,9 +19,15 @@ class AgendaDayPagerAdapter internal constructor(
     }
 
     override fun getItem(position: Int): Fragment {
+        val dayString = if (position == 0) {
+            BuildConfig.EVENT_DAY_ONE_STRING
+        } else {
+            BuildConfig.EVENT_DAY_TWO_STRING
+        }
+
         return AgendaDayFragment.newInstance(
             myAgenda,
-            if (position == 0) Schedule.MONDAY else Schedule.TUESDAY
+            dayString
         )
     }
 

--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaFragment.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaFragment.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.mentalmachines.droidcon_boston.BuildConfig
 import com.mentalmachines.droidcon_boston.R
 import kotlinx.android.synthetic.main.agenda_fragment.*
 import java.util.*
@@ -43,7 +44,11 @@ class AgendaFragment : Fragment() {
             // set current day to second if today matches
             val today = Calendar.getInstance()
             val dayTwo = Calendar.getInstance()
-            dayTwo.set(EVENT_YEAR, EVENT_MONTH, EVENT_DAY_ONE)
+            dayTwo.set(
+                BuildConfig.EVENT_YEAR,
+                BuildConfig.EVENT_MONTH - 1, // Calendar is 0 indexed
+                BuildConfig.EVENT_DAY_TWO
+            )
             if (today == dayTwo) {
                 viewpager.currentItem = 1
             }
@@ -87,9 +92,5 @@ class AgendaFragment : Fragment() {
             fragment.arguments = args
             return fragment
         }
-
-        private const val EVENT_YEAR = 2018
-        private const val EVENT_MONTH = Calendar.MARCH
-        private const val EVENT_DAY_ONE = 27
     }
 }

--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/search/SearchViewModel.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/search/SearchViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ValueEventListener
+import com.mentalmachines.droidcon_boston.BuildConfig
 import com.mentalmachines.droidcon_boston.data.FirebaseDatabase
 import com.mentalmachines.droidcon_boston.data.Schedule
 import com.mentalmachines.droidcon_boston.firebase.FirebaseHelper
@@ -13,7 +14,6 @@ import timber.log.Timber
 
 class SearchViewModel : ViewModel() {
     private val firebaseHelper = FirebaseHelper.instance
-    private val conferenceYear = "2018"
 
     private val _scheduleRows = MutableLiveData<List<Schedule.ScheduleRow>>()
     val scheduleRows: LiveData<List<Schedule.ScheduleRow>> = _scheduleRows
@@ -27,7 +27,7 @@ class SearchViewModel : ViewModel() {
                 if (data != null) {
                     val scheduleRow = data.toScheduleRow(key)
 
-                    if (scheduleRow.date.endsWith(conferenceYear)) {
+                    if (scheduleRow.date.endsWith(BuildConfig.EVENT_YEAR.toString())) {
                         rows.add(scheduleRow)
                     }
                 }


### PR DESCRIPTION
This way we have one source of truth for event dates, and whenever we need to update the app we have one spot to do so. 

I'll leave ticket #157 open though because we will eventually need to convert to the 2019 dates once the data is there. 