### PR TITLE
Disable the evaluateViolations command until issues can be properly addressed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
     - run:
         name: Static Analysis Checks
-        command: cd Droidcon-Boston && ./gradlew detekt ktlintCheck lint evaluateViolations
+        command: cd Droidcon-Boston && ./gradlew detekt ktlintCheck lint
         
     - run:
         name: Run Tests


### PR DESCRIPTION
- failing the build on the evaluateViolations task is slowing people down right now
- this is add odds with the goal of adding these checks in the first place
- this PR disables the failing of the build if there are lint issues until the overall experience and issue count can be improved (likely after the conference)