### PR TITLE
Make MainActivity singleTop Fixes #185

### DIFF
--- a/Droidcon-Boston/app/src/main/AndroidManifest.xml
+++ b/Droidcon-Boston/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         <!-- Main Activity -->
         <activity
             android:name=".views.MainActivity"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:screenOrientation="portrait"
             android:taskAffinity="" />
 


### PR DESCRIPTION
https://github.com/Droidcon-Boston/conference-app-android/issues/185

This was to avoid putting 2 activites into the Recents stack when the app is started
Before this change, when the app started, and the user viewed the Recents list there would be 2 tasks listed

Using singleTop here aims to avoid a new task for the MainActivity while also avoiding creating multiple instances of MainActivity in respsone to push notifications which is what the previous SingleTask launch mode was aiming to achieve