### PR TITLE
Issue #164: Try to fix app crash possibly related to animation

### DIFF
--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaDayFragment.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/AgendaDayFragment.kt
@@ -41,6 +41,7 @@ import timber.log.Timber
  */
 class AgendaDayFragment : Fragment(), FlexibleAdapter.OnItemClickListener {
     private val timeHeaders = HashMap<String, ScheduleAdapterItemHeader>()
+    private val floatAnimation = AnimatorSet()
 
     private var headerAdapter: FlexibleAdapter<*>? = null
     private lateinit var layoutManager: LinearLayoutManager
@@ -235,7 +236,6 @@ class AgendaDayFragment : Fragment(), FlexibleAdapter.OnItemClickListener {
         floatDownAnimator.duration = JumpToCurrent.ButtonTranslation.duration
         floatDownAnimator.interpolator = LinearInterpolator()
 
-        val floatAnimation = AnimatorSet()
         floatAnimation.playSequentially(floatUpAnimator, floatDownAnimator)
         floatAnimation.start()
         floatAnimation.addListener(object : AnimatorListenerAdapter() {
@@ -247,6 +247,8 @@ class AgendaDayFragment : Fragment(), FlexibleAdapter.OnItemClickListener {
 
     override fun onDestroyView() {
         super.onDestroyView()
+
+        floatAnimation.cancel();
         agendaRecyler.removeOnChildAttachStateChangeListener(currentSessionVisibleListener)
         activity?.supportFragmentManager?.removeOnBackStackChangedListener(backStackChangeListener)
     }


### PR DESCRIPTION
I noticed that in my build the random crash happens on line 243 inside addListener().  I also noticed that when the app crashes it appears random: I'll be using the app, changing screens and scrolling up and down and suddenly it crashes.

I wondered if the issue is the listener is leaking and needs to be canceled when the view is destroyed:

https://developer.android.com/reference/android/animation/AnimatorSet.html#cancel()

I don't know animations but I tried this fix and used the app a while and it didn't crash and the dancing Android is working. Perhaps someone can review if this fix would be appropriate?