### PR TITLE
Fix Issue 165 using a workaround for now

### DIFF
--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/ScheduleAdapterItem.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/ScheduleAdapterItem.kt
@@ -15,7 +15,6 @@ import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractSectionableItem
 import eu.davidea.flexibleadapter.items.IFlexible
 import eu.davidea.viewholders.FlexibleViewHolder
-import kotlinx.android.synthetic.main.list_item_schedule_search.view.*
 import timber.log.Timber
 import java.text.ParseException
 import java.text.SimpleDateFormat

--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/ScheduleAdapterItem.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/agenda/ScheduleAdapterItem.kt
@@ -15,6 +15,7 @@ import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractSectionableItem
 import eu.davidea.flexibleadapter.items.IFlexible
 import eu.davidea.viewholders.FlexibleViewHolder
+import kotlinx.android.synthetic.main.list_item_schedule_search.view.*
 import timber.log.Timber
 import java.text.ParseException
 import java.text.SimpleDateFormat
@@ -91,7 +92,12 @@ class ScheduleAdapterItem internal constructor(
                     else View.INVISIBLE
             holder.sessionLayout.visibility = View.VISIBLE
             holder.title.text = itemData.talkTitle
-            holder.room.text = itemData.room
+
+            // WORKAROUND FOR https://github.com/Droidcon-Boston/conference-app-android/issues/165
+            // If the talk title is Check-In then hardcode the room name to be the lobby
+            if (itemData.talkTitle.toLowerCase().contains("check-in")) {
+                holder.room.text = "Calderwood Pavilion Lobby"
+            }
 
             if (itemData.photoUrlMap.size == 0) {
                 holder.rootLayout.background = null

--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
@@ -107,7 +107,6 @@ class AgendaDetailFragment : Fragment() {
         if (viewModel.talkTitle.toLowerCase().contains("check-in")) {
             tv_agenda_detail_room.text =
                 resources.getString(R.string.str_agenda_detail_room, "Calderwood Pavilion Lobby")
-
         } else {
             tv_agenda_detail_room.text =
                 resources.getString(R.string.str_agenda_detail_room, viewModel.room)

--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
@@ -101,8 +101,17 @@ class AgendaDetailFragment : Fragment() {
 
     private fun populateView() {
         tv_agenda_detail_title.text = viewModel.talkTitle
-        tv_agenda_detail_room.text =
+
+        // WORKAROUND FOR https://github.com/Droidcon-Boston/conference-app-android/issues/165
+        // If the talk title is Check-In then hardcode the room name to be the lobby
+        if (viewModel.talkTitle.toLowerCase().contains("check-in")) {
+            tv_agenda_detail_room.text =
+                resources.getString(R.string.str_agenda_detail_room, "Calderwood Pavilion Lobby")
+
+        } else {
+            tv_agenda_detail_room.text =
                 resources.getString(R.string.str_agenda_detail_room, viewModel.room)
+        }
         tv_agenda_detail_time.text = resources.getString(
             R.string.str_agenda_detail_time,
             viewModel.startTime,


### PR DESCRIPTION
This PR has a suggested fix for https://github.com/Droidcon-Boston/conference-app-android/issues/165.

In Firebase database, the children of /conferenceData/events do not share the same model data (though they should). Some of the child nodes represent a talk with a speaker and other fields while other child nodes represent a "General Event" from SlidesUp which has less data, notably no fields containing room information.  The result is that the app displays "null" in the Agenda Detail view.

Without changing anything about the data in SlidesUp at this late date which would in turn affect data structure in Firebase I suggest we inspect the title for these "Check-In" events and hardcode the room name in order to preserve low risk. I don't see other General Events in SlidesUp right now but if we create any they will likely have the same issue. 

A better fix in the future would ensure that all children of /conferenceData/events have the same model data. And we could also depend on the isGeneralEvent key that is written by SlidesUp and, if true, do something different in the UI.

Here is what the Agenda and AgendaDetail look like with the fix:

![AgendaDetail](https://user-images.githubusercontent.com/15278837/55200547-078a6c80-5195-11e9-9b4c-2334cb6aa206.jpg)
![AgendaListItem](https://user-images.githubusercontent.com/15278837/55200548-078a6c80-5195-11e9-9d0b-b81ba9e13072.jpg)