### PR TITLE
Explicitly tell this fragment not to retain its state. 

### DIFF
--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
@@ -59,6 +59,7 @@ class AgendaDetailFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        retainInstance = false
         setHasOptionsMenu(true)
     }
 


### PR DESCRIPTION
Issues when leaving the app and resuming on some devices (i.e. Twitter, email, etc) Fixes #201 