### PR TITLE
Use star icon instead of heart within AgendaDetail fab

### DIFF
--- a/Droidcon-Boston/app/src/main/res/layout/agenda_detail_fragment.xml
+++ b/Droidcon-Boston/app/src/main/res/layout/agenda_detail_fragment.xml
@@ -97,7 +97,7 @@
             android:layout_marginEnd="16dp"
             android:tint="@android:color/white"
             app:backgroundTint="@color/colorLightGray"
-            app:srcCompat="@drawable/ic_heart" />
+            app:srcCompat="@drawable/ic_star" />
 
 
         <LinearLayout


### PR DESCRIPTION
This was so the fab icon matched the star icon being used in the agenda fragment

fixes #186 

## Proposed Changes
- use the star icon in the AgendaDetailFragment fab

## Screenshots
![Screen Shot 2019-03-30 at 3 43 05 PM](https://user-images.githubusercontent.com/3383930/55282530-a2548980-5302-11e9-9a08-7a11417126cb.png)
