### PR TITLE
Update share to twitter text

### DIFF
--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/detail/AgendaDetailFragment.kt
@@ -250,7 +250,6 @@ class AgendaDetailFragment : Fragment() {
                 scheduleDetail.listRow.talkDescription.getHtmlFormattedSpanned()
 
         tv_agenda_detail_description.movementMethod = LinkMovementMethod.getInstance()
-        tv_agenda_detail_shareText.text = resources.getString(R.string.sharing_twitter_title)
         tv_agenda_detail_shareText.setOnClickListener {
             val twitter = viewModel.getSpeaker(scheduleDetail.listRow.primarySpeakerName)?.socialProfiles?.get("twitter")
 

--- a/Droidcon-Boston/app/src/main/res/layout/agenda_detail_fragment.xml
+++ b/Droidcon-Boston/app/src/main/res/layout/agenda_detail_fragment.xml
@@ -147,18 +147,20 @@
 
                 <TextView
                     android:id="@+id/tv_agenda_detail_shareText"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:textAlignment="center"
                     android:textColor="@android:color/black"
                     android:fontFamily="sans-serif"
-                    android:maxLines="1"
-                    android:ellipsize="end"
-                    android:textSize="@dimen/def_padding_large"
+                    android:maxHeight="32dp"
+                    android:textSize="18sp"
+                    app:autoSizeMaxTextSize="18sp"
+                    app:autoSizeMinTextSize="16sp"
+                    app:autoSizeStepGranularity="1sp"
+                    app:autoSizeTextType="uniform"
                     android:layout_centerVertical="true"
                     android:drawableStart="@drawable/ic_twitter_logo_blue"
                     android:drawablePadding="16dp"
-                    tools:text="Enjoy this talk? Let your followers know!"/>
+                    android:text="@string/sharing_twitter_title"/>
 
             </RelativeLayout>
 

--- a/Droidcon-Boston/app/src/main/res/values/strings.xml
+++ b/Droidcon-Boston/app/src/main/res/values/strings.xml
@@ -68,7 +68,7 @@
     <string name="submit">Submit</string>
     <string name="cancel">Cancel</string>
     <string name="err_select_rating">Please select a rating.</string>
-    <string name="sharing_twitter_title">Enjoy this talk? Let your followers know!</string>
+    <string name="sharing_twitter_title">Share this session</string>
 
     <string name="twitter_handel">\@%s</string>
 


### PR DESCRIPTION
fixes #213 

Adjust the sizing of the text as well as the copy so it should be visible on most screens

## Proposed Changes
- setup autosizing for the textview that controls the "share session to twitter" text
- shorten the copy for that text so there is less to fit

## Screenshots
<img width="305" alt="Screen Shot 2019-03-31 at 10 54 31 AM" src="https://user-images.githubusercontent.com/3383930/55292747-61608180-53a3-11e9-96ca-1277f0c978c9.png">
