### PR TITLE
Fix crash when sharing to twitter

### DIFF
--- a/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/MainActivity.kt
+++ b/Droidcon-Boston/app/src/main/java/com/mentalmachines/droidcon_boston/views/MainActivity.kt
@@ -38,6 +38,8 @@ class MainActivity : AppCompatActivity() {
 
         initNavDrawerToggle()
 
+        setInitialFragment(savedInstanceState)
+
         initFragmentsFromIntent(intent)
 
         initSearchDialog()
@@ -51,18 +53,21 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun initFragmentsFromIntent(initialIntent: Intent) {
-        replaceFragment(getString(string.str_agenda))
+    private fun setInitialFragment(savedInstanceState: Bundle?) {
+        if (savedInstanceState == null) {
+            replaceFragment(getString(string.str_agenda))
+        }
+    }
 
+    private fun initFragmentsFromIntent(initialIntent: Intent) {
         val sessionDetails = initialIntent.extras?.getString(EXTRA_SESSION_DETAILS)
         if (!TextUtils.isEmpty(sessionDetails)) {
+            replaceFragment(getString(string.str_agenda))
             AgendaDetailFragment.addDetailFragmentToStack(
                 supportFragmentManager,
                 ServiceLocator.gson.fromJson(sessionDetails, ScheduleRow::class.java)
             )
             updateSelectedNavItem(supportFragmentManager)
-        } else {
-            navView.setCheckedItem(id.nav_agenda)
         }
     }
 


### PR DESCRIPTION
fixes #214 

Previously, when MainActivity.onCreate() was called the AgendaFragment would always be added
This would lead to the AgendaDetailFragment getting added multiple times if the user went UserDetailFragment -> Share to Twitter -> Hit Back (now on agenda screen) -> Click a session again

Having multiple AgendaDetailFragments appears to have been causing some state inconsistency in the fragment manager and leading to a crash